### PR TITLE
make integrant keys consistent and make fixtures fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,5 +42,5 @@ jobs:
           MANAGEMENT_CLIENT_SECRET: ${{ secrets.MANAGEMENT_CLIENT_SECRET }}
           TEST_CLIENT_ID: ${{ secrets.TEST_CLIENT_ID }}
           DOCKER_HOST: unix:///var/run/docker.sock
-          JAVA_TOOL_OPTIONS: -Ddocker.api.version=1.44
+          DOCKER_API_VERSION: "1.44"
         run: lein test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,4 +43,7 @@ jobs:
           TEST_CLIENT_ID: ${{ secrets.TEST_CLIENT_ID }}
           DOCKER_HOST: unix:///var/run/docker.sock
           DOCKER_API_VERSION: "1.44"
-        run: lein test
+        run: |
+          echo "DOCKER_HOST=$DOCKER_HOST"
+          echo "DOCKER_API_VERSION=$DOCKER_API_VERSION"
+          lein test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      docker:
+        image: docker:latest
+
     env: # Environment variable for the entire job
       CI_ENV: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,21 +29,9 @@ jobs:
           lein version  # Verify installation
       - name: Install dependencies
         run: lein deps
-      - name: Debug Docker for Testcontainers
-        run: |
-          echo "DOCKER_HOST=$DOCKER_HOST"
-          ls -l /var/run/docker.sock || true
-          docker version || true
-          docker info || true
-          echo "ENV VARS $(env | sort | grep -E '^DOCKER')" || true
       - name: Run tests
         env:
           MANAGEMENT_CLIENT_ID: ${{ secrets.MANAGEMENT_CLIENT_ID }}
           MANAGEMENT_CLIENT_SECRET: ${{ secrets.MANAGEMENT_CLIENT_SECRET }}
           TEST_CLIENT_ID: ${{ secrets.TEST_CLIENT_ID }}
-          DOCKER_HOST: unix:///var/run/docker.sock
-          DOCKER_API_VERSION: "1.44"
-        run: |
-          echo "DOCKER_HOST=$DOCKER_HOST"
-          echo "DOCKER_API_VERSION=$DOCKER_API_VERSION"
-          lein test
+        run: lein test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,12 @@ jobs:
           lein version  # Verify installation
       - name: Install dependencies
         run: lein deps
+      - name: Debug Docker for Testcontainers
+        run: |
+          echo "DOCKER_HOST=$DOCKER_HOST"
+          ls -l /var/run/docker.sock || true
+          docker version || true
+          docker info || true
       - name: Run tests
         env:
           MANAGEMENT_CLIENT_ID: ${{ secrets.MANAGEMENT_CLIENT_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
           ls -l /var/run/docker.sock || true
           docker version || true
           docker info || true
+          env | sort | grep -E '^DOCKER' || true
       - name: Run tests
         env:
           MANAGEMENT_CLIENT_ID: ${{ secrets.MANAGEMENT_CLIENT_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           ls -l /var/run/docker.sock || true
           docker version || true
           docker info || true
-          env | sort | grep -E '^DOCKER' || true
+          echo "ENV VARS $(env | sort | grep -E '^DOCKER')" || true
       - name: Run tests
         env:
           MANAGEMENT_CLIENT_ID: ${{ secrets.MANAGEMENT_CLIENT_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    services:
-      docker:
-        image: docker:latest
-
     env: # Environment variable for the entire job
       CI_ENV: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,6 @@ jobs:
           MANAGEMENT_CLIENT_ID: ${{ secrets.MANAGEMENT_CLIENT_ID }}
           MANAGEMENT_CLIENT_SECRET: ${{ secrets.MANAGEMENT_CLIENT_SECRET }}
           TEST_CLIENT_ID: ${{ secrets.TEST_CLIENT_ID }}
+          DOCKER_HOST: unix:///var/run/docker.sock
+          JAVA_TOOL_OPTIONS: -Ddocker.api.version=1.44
         run: lein test

--- a/project.clj
+++ b/project.clj
@@ -3,32 +3,32 @@
   :url "http://api.pigeon-scoops.com/"
   :min-lein-version "2.0.0"
   :main pigeon-scoops-backend.server
-  :dependencies [[org.clojure/clojure "1.12.3"]
+  :dependencies [[org.clojure/clojure "1.12.4"]
                  [ring "1.15.3"]
                  [integrant "1.0.1"]
                  [environ "1.2.0"]
-                 [metosin/reitit "0.9.2"]
+                 [metosin/reitit "0.10.0"]
                  [seancorfield/next.jdbc "1.2.659"]
-                 [org.postgresql/postgresql "42.7.8"]
+                 [org.postgresql/postgresql "42.7.10"]
                  [clj-http "3.13.1"]
                  [ovotech/ring-jwt "2.3.0"]
                  [camel-snake-kebab "0.4.3"]
                  [com.zaxxer/HikariCP "7.0.2"]
-                 [org.flywaydb/flyway-database-postgresql "11.17.0"]
+                 [org.flywaydb/flyway-database-postgresql "12.0.1"]
                  [ring-cors "0.1.13"]
                  [ring/ring-codec "1.3.0"]
-                 [com.github.seancorfield/honeysql "2.7.1350"]
-                 [org.clojure/tools.cli "1.2.245"]
+                 [com.github.seancorfield/honeysql "2.7.1368"]
+                 [org.clojure/tools.cli "1.3.250"]
 
                  ;; Logging
-                 [ch.qos.logback/logback-classic "1.5.21"]
-                 [ch.qos.logback/logback-core "1.5.21"]
+                 [ch.qos.logback/logback-classic "1.5.32"]
+                 [ch.qos.logback/logback-core "1.5.32"]
                  [org.slf4j/slf4j-api "2.0.17"]
                  [org.slf4j/jcl-over-slf4j "2.0.17"]
                  [org.slf4j/log4j-over-slf4j "2.0.17"]
                  [org.slf4j/osgi-over-slf4j "2.0.17"]
                  [org.slf4j/jul-to-slf4j "2.0.17"]
-                 [org.apache.logging.log4j/log4j-to-slf4j "2.25.2"]]
+                 [org.apache.logging.log4j/log4j-to-slf4j "2.25.3"]]
   :plugins [[lein-ancient "0.7.0"]
             [com.github.clj-kondo/lein-clj-kondo "0.2.5"]]
   :profiles {:uberjar {:aot :all}
@@ -37,5 +37,5 @@
                        :resource-paths ["dev/resources"]
                        :dependencies   [[ring/ring-mock "0.6.2"]
                                         [integrant/repl "0.5.0"]
-                                        [org.testcontainers/postgresql "1.21.3"]]}}
+                                        [org.testcontainers/postgresql "1.21.4"]]}}
   :uberjar-name "pigeon-scoops.jar")

--- a/resources/db-task-config.edn
+++ b/resources/db-task-config.edn
@@ -1,3 +1,3 @@
 {:db/postgres         {:jdbc-url "jdbc-url"}
- :tasks/migration     {:jdbc-url #ig/ref :db/postgres}
- :tasks/accept-orders {:jdbc-url #ig/ref :db/postgres}}
+ :db-tasks/migration     {:jdbc-url #ig/ref :db/postgres}
+ :db-tasks/accept-orders {:jdbc-url #ig/ref :db/postgres}}

--- a/resources/server-config.edn
+++ b/resources/server-config.edn
@@ -1,6 +1,6 @@
-{:server/jetty              {:handler #ig/ref :pigeon-scoops-backend/app
+{:server/jetty              {:handler #ig/ref :server/routes
                              :port    3000}
- :pigeon-scoops-backend/app {:jdbc-url #ig/ref :db/postgres
+ :server/routes {:jdbc-url #ig/ref :db/postgres
                              :auth     #ig/ref :auth/auth0}
  :db/postgres               {:jdbc-url "jdbc-url"}
  :auth/auth0                {:test-client-id           "test-client-id"

--- a/src/pigeon_scoops_backend/db.clj
+++ b/src/pigeon_scoops_backend/db.clj
@@ -1,4 +1,4 @@
-(ns pigeon-scoops-backend.config
+(ns pigeon-scoops-backend.db
   (:require [environ.core :refer [env]]
             [integrant.core :as ig]
             [next.jdbc :as jdbc]

--- a/src/pigeon_scoops_backend/db_tasks.clj
+++ b/src/pigeon_scoops_backend/db_tasks.clj
@@ -4,7 +4,7 @@
             [clojure.tools.cli :as cli]
             [integrant.core :as ig]
             [next.jdbc :as jdbc]
-            [pigeon-scoops-backend.config :as config]
+            [pigeon-scoops-backend.db :as config]
             [pigeon-scoops-backend.menu.db :as menu-db]
             [pigeon-scoops-backend.user-order.db :as order-db]
             [pigeon-scoops-backend.utils :refer [end-time with-connection]])
@@ -19,7 +19,7 @@
     :parse-fn keyword]])
 
 
-(defmethod ig/init-key :tasks/migration [_ {:keys [jdbc-url]}]
+(defmethod ig/init-key :db-tasks/migration [_ {:keys [jdbc-url]}]
   (fn []
     (println "\nMigrating database")
     (-> (Flyway/configure)
@@ -29,7 +29,7 @@
         (.migrate))))
 
 
-(defmethod ig/init-key :tasks/accept-orders [_ {:keys [jdbc-url]}]
+(defmethod ig/init-key :db-tasks/accept-orders [_ {:keys [jdbc-url]}]
   (fn []
     (println "\nAccepting orders on expired menus")
     (with-connection

--- a/src/pigeon_scoops_backend/server.clj
+++ b/src/pigeon_scoops_backend/server.clj
@@ -2,7 +2,7 @@
   (:gen-class)
   (:require [environ.core :refer [env]]
             [integrant.core :as ig]
-            [pigeon-scoops-backend.config :as config]
+            [pigeon-scoops-backend.db :as config]
             [pigeon-scoops-backend.router :as router]
             [ring.adapter.jetty :as jetty])
   (:import (org.eclipse.jetty.server Server)))
@@ -22,7 +22,7 @@
   (println "\nServer running on port" port)
   (jetty/run-jetty handler {:port port :join? false}))
 
-(defmethod ig/init-key :pigeon-scoops-backend/app [_ config]
+(defmethod ig/init-key :server/routes [_ config]
   (println "\nStarting app")
   (router/routes config))
 


### PR DESCRIPTION
integrant expects the key namespaces to correspond to actual namespaces

I also found that if the fixtures in tests failed, the tests were skipped, so I added (strict-fixture) that will fail on errors in setiup/teardown