### PR TITLE
Add options to retrieve order and menu lists with sub entities included

### DIFF
--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -254,7 +254,6 @@
          :body)
     results))
 
-
 (defn init-app []
   (if (.exists (io/file users-config))
     (load-test-user)

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -10,6 +10,7 @@
             [pigeon-scoops-backend.auth :as auth0]
             [pigeon-scoops-backend.db :as db]
             [pigeon-scoops-backend.db-tasks]
+            [pigeon-scoops-backend.user-order.db :as order-db]
             [ring.mock.request :as mock]
             [clojure.pprint :refer [pprint]])
   (:import (java.util UUID)
@@ -219,11 +220,13 @@
         order-map (->> "dev/resources/seed/orders.json"
                        (slurp)
                        (m/decode "application/json")
-                       (map #(vector (:id %) (-> (make-request :post "/v1/orders"
-                                                               {:auth true
-                                                                :body (update-keys % (fn [k] (keyword "user-order" (name k))))})
-                                                 :body
-                                                 :id)))
+                       (map #(let [pair (vector (:id %) (-> (make-request :post "/v1/orders"
+                                                                          {:auth true
+                                                                           :body (update-keys % (fn [k] (keyword "user-order" (name k))))})
+                                                            :body
+                                                            :id))]
+                               (Thread/sleep 500)
+                               pair))
                        (into {}))
         order-items (->> "dev/resources/seed/flavor_amounts.json"
                          (slurp)
@@ -236,16 +239,21 @@
                                                          :order-item/amount-unit (keyword (last (str/split (:amount_unit_type %) #"\."))
                                                                                           (:amount_unit %))}})
                                    :body
-                                   :id)))]
-    {:grocery-map   grocery-map
-     :grocery-units units
-     :recipe-map    recipe-map
-     :ingredients   ingredients
-     :order-map     order-map
-     :order-items   order-items
-     :menu-id       menu-id
-     :menu-item-id menu-item-id
-     :mnu-item-size-ids menu-item-size-ids}))
+                                   :id)))
+        results {:grocery-map   grocery-map
+                 :grocery-units units
+                 :recipe-map    recipe-map
+                 :ingredients   ingredients
+                 :order-map     order-map
+                 :order-items   order-items
+                 :menu-id       menu-id
+                 :menu-item-id menu-item-id
+                 :mnu-item-size-ids menu-item-size-ids}]
+    (->> (make-request :get (str "/v1/orders?detailed=true&admin=true")
+                       {:auth true})
+         :body)
+    results))
+
 
 (defn init-app []
   (if (.exists (io/file users-config))
@@ -302,10 +310,16 @@
   (map #(auth0/delete-user! (:auth/auth0 state/system) (:user_id %))
        (filter #(str/starts-with? (:email %) "integration-test")
                (auth0/get-users (:auth/auth0 state/system))))
-  (make-request :get "/v1/account"
-                {:auth true})
+  (-> (make-request :get "/v1/orders?detailed=true&admin=true"
+                    {:auth true})
+      :body
+      (first)
+      :user-order/id
+      (#(make-request :get (str "/v1/orders/" %)
+                      {:auth true})))
   (.getJdbcUrl (:connectable (:db/postgres state/system)))
   (make-test-users 2)
+  (order-db/find-all-orders (:db/postgres state/system) nil true)
   (go)
   (go false)
   (pprint @tokens)

--- a/src/pigeon_scoops_backend/menu/db.clj
+++ b/src/pigeon_scoops_backend/menu/db.clj
@@ -27,7 +27,7 @@
                                    (map #(apply-db-str->keyword % :menu-item-size/amount-unit))
                                    (group-by :menu-item-size/menu-item-id)))]
         (->> menu-items
-             (map #(assoc % :menu-item/sizes (get menu-item-sizes (:menu-item/id %))))
+             (map #(assoc % :menu-item/sizes (get menu-item-sizes (:menu-item/id %) [])))
              (group-by :menu-item/menu-id))))))
 
 (defn find-menu-item-by-id [db menu-item-id]
@@ -39,22 +39,31 @@
 
 (defn find-all-menus
   ([db]
-   (find-all-menus db false false))
+   (find-all-menus db false false false))
   ([db include-inactive?]
-   (find-all-menus db include-inactive? false))
-  ([db include-inactive? include-deleted?]
+   (find-all-menus db include-inactive? false false))
+  ([db include-inactive? detailed?]
+   (find-all-menus db include-inactive? detailed? false))
+  ([db include-inactive? detailed? include-deleted?]
    (with-connection
      db
      (fn [db]
-       (->> (sql/find-by-keys
-             db
-             :menu
-             (if (and include-inactive? include-deleted?)
-               :all
-               (cond-> {}
-                 (not include-inactive?) (assoc :active true)
-                 (not include-deleted?) (assoc :deleted false))))
-            (map #(apply-db-str->keyword % :menu/duration-type)))))))
+       (let [menus (->> (sql/find-by-keys
+                         db
+                         :menu
+                         (if (and include-inactive? include-deleted?)
+                           :all
+                           (cond-> {}
+                             (not include-inactive?) (assoc :active true)
+                             (not include-deleted?) (assoc :deleted false))))
+                        (map #(apply-db-str->keyword % :menu/duration-type)))
+             menu-items (when detailed?
+                          (->> menus
+                               (map :menu/id)
+                               (apply (partial find-menu-items db))))]
+         (mapv #(assoc % :menu/items (get menu-items (:menu/id %)))
+               menus))))))
+
 
 (defn insert-menu! [db menu]
   (sql/insert! db :menu

--- a/src/pigeon_scoops_backend/menu/db.clj
+++ b/src/pigeon_scoops_backend/menu/db.clj
@@ -64,7 +64,6 @@
          (mapv #(assoc % :menu/items (get menu-items (:menu/id %)))
                menus))))))
 
-
 (defn insert-menu! [db menu]
   (sql/insert! db :menu
                (-> menu

--- a/src/pigeon_scoops_backend/menu/handlers.clj
+++ b/src/pigeon_scoops_backend/menu/handlers.clj
@@ -7,7 +7,8 @@
 
 (defn list-all-menus [db]
   (fn [request]
-    (rr/response (vec (menu-db/find-all-menus db (-> request :parameters :query :include-inactive))))))
+    (let [{:keys [detailed include-inactive]} (-> request :parameters :query)]
+      (rr/response (vec (menu-db/find-all-menus db include-inactive detailed))))))
 
 (defn create-menu! [db]
   (fn [request]

--- a/src/pigeon_scoops_backend/menu/routes.clj
+++ b/src/pigeon_scoops_backend/menu/routes.clj
@@ -11,7 +11,8 @@
 (defn routes [{db :jdbc-url}]
   ["/menus" {:openapi    {:tags ["menus"]}}
    ["" {:get  {:handler   (menu/list-all-menus db)
-               :parameters {:query {(ds/opt :include-inactive)      boolean?}}
+               :parameters {:query {(ds/opt :include-inactive) boolean?
+                                    (ds/opt :detailed) boolean?}}
                :responses {200 {:body [responses/menu]}}
                :summary   "list of menus"}
         :post {:handler    (menu/create-menu! db)

--- a/src/pigeon_scoops_backend/user_order/db.clj
+++ b/src/pigeon_scoops_backend/user_order/db.clj
@@ -42,7 +42,7 @@
                                   (apply (partial find-all-order-items db))))]
            (->> orders
                 (mapv #(assoc % :user-order/status (infer-order-status (get order-items (:user-order/id %)))
-                                :user-order/items (get order-items (:user-order/id %))))
+                              :user-order/items (get order-items (:user-order/id %))))
                 (mapv #(apply-db-str->keyword % :user-order/amount-unit :user-order/status)))))))
 
 (defn find-order-by-id [db order-id]

--- a/src/pigeon_scoops_backend/user_order/db.clj
+++ b/src/pigeon_scoops_backend/user_order/db.clj
@@ -9,13 +9,14 @@
                                                  with-connection]]
             [pigeon-scoops-backend.user-order.transforms :refer [infer-order-status]]))
 
-(defn find-all-order-items [db order-id]
-  (map #(apply-db-str->keyword %
-                               :order-item/status :order-item/amount-unit)
-       (sql/query db (-> (h/select :order-item/*)
-                         (h/from :order-item)
-                         (h/where [:= :order-item/order-id order-id])
-                         (hsql/format)))))
+(defn find-all-order-items [db order-id & order-ids]
+  (->> (conj order-ids order-id)
+       (#(sql/query db (-> (h/select :order-item/*)
+                           (h/from :order-item)
+                           (h/where [:in :order-item/order-id %])
+                           (hsql/format))))
+       (map #(apply-db-str->keyword % :order-item/status :order-item/amount-unit))
+       (group-by :order-item/order-id)))
 
 (defn find-all-items-by-status [db status]
   (map #(apply-db-str->keyword %
@@ -26,30 +27,35 @@
                          (hsql/format)))))
 
 (defn find-all-orders
-  [db user-id]
+  [db user-id detailed?]
   (with-connection
     db (fn [db]
-         (->> (sql/find-by-keys
-               db
-               :user-order
-               (if user-id
-                 {:user-order/user-id user-id}
-                 :all))
-              (mapv #(assoc % :user-order/status
-                            (infer-order-status
-                             (find-all-order-items db (:user-order/id %)))))
-              (map #(apply-db-str->keyword % :user-order/amount-unit :user-order/status))))))
+         (let [orders (sql/find-by-keys
+                       db
+                       :user-order
+                       (if user-id
+                         {:user-order/user-id user-id}
+                         :all))
+               order-items (when detailed?
+                             (->> orders
+                                  (map :user-order/id)
+                                  (apply (partial find-all-order-items db))))]
+           (->> orders
+                (mapv #(assoc % :user-order/status (infer-order-status (get order-items (:user-order/id %)))
+                                :user-order/items (get order-items (:user-order/id %))))
+                (mapv #(apply-db-str->keyword % :user-order/amount-unit :user-order/status)))))))
 
 (defn find-order-by-id [db order-id]
   (with-connection
     db (fn [db]
          (let [[order] (sql/find-by-keys db :user-order {:id order-id})
-               items (find-all-order-items db order-id)]
+               items (get (find-all-order-items db order-id)
+                          order-id)]
            (when (seq order)
              (-> order
-                 (assoc :user-order/status (infer-order-status items))
-                 (apply-db-str->keyword :user-order/amount-unit :user-order/status)
-                 (assoc :user-order/items items)))))))
+                 (assoc :user-order/status (infer-order-status items)
+                        :user-order/items items)
+                 (apply-db-str->keyword :user-order/amount-unit :user-order/status)))))))
 
 (defn find-order-item-by-id [db order-item-id]
   (-> (sql/find-by-keys db :order-item {:id order-item-id})

--- a/src/pigeon_scoops_backend/user_order/handlers.clj
+++ b/src/pigeon_scoops_backend/user_order/handlers.clj
@@ -14,11 +14,11 @@
 (defn list-all-orders [db]
   (fn [request]
     (let [production-manager? (production-manager? request)
-          admin-request? (-> request :parameters :query :admin)
+          {admin-request? :admin detailed? :detailed} (-> request :parameters :query)
           uid (when-not (and admin-request?
                              production-manager?)
                 (-> request :claims :sub))]
-      (rr/response (vec (order-db/find-all-orders db uid))))))
+      (rr/response (vec (order-db/find-all-orders db uid detailed?))))))
 
 (defn create-order! [db]
   (fn [request]

--- a/src/pigeon_scoops_backend/user_order/routes.clj
+++ b/src/pigeon_scoops_backend/user_order/routes.clj
@@ -23,7 +23,8 @@
                            :summary "mark all in progress items for this recipe as complete"}}]]
    ["/orders" {:openapi    {:tags ["orders"]}}
     ["" {:get  {:handler   (order/list-all-orders db)
-                :parameters {:query {(ds/opt :admin) boolean?}}
+                :parameters {:query {(ds/opt :admin) boolean?
+                                     (ds/opt :detailed) boolean?}}
                 :responses {200 {:body [responses/order]}}
                 :summary "list of orders"}
          :post {:handler    (order/create-order! db)

--- a/test/pigeon_scoops_backend/menu/integration_test.clj
+++ b/test/pigeon_scoops_backend/menu/integration_test.clj
@@ -37,13 +37,15 @@
       (are [include-inactive? detailed?]
         (let [{:keys [status body]} (ts/test-endpoint :get "/v1/menus" {:use-auth? true
                                                                         :params {:include-inactive include-inactive?
-                                                                                 :detailed detailed?}})]
-          (and (= status 200)
-               (vector? body)
-               (some #(= (parse-uuid (:menu/id %)) active-menu-id) body)
-               (= include-inactive? (true? (some #(= (parse-uuid (:menu/id %)) inactive-menu-id) body)))
-               (every? #(= detailed? (not= (count (:menu/items %)) 0))
-                       body)))
+                                                                                 :detailed detailed?}})
+              body (filter #(#{active-menu-id inactive-menu-id} (parse-uuid (:menu/id %))) body)
+              conditions {:status (= status 200)
+                          :not-empty (pos? (count body))
+                          :has-active (some #(= (parse-uuid (:menu/id %)) active-menu-id) body)
+                          :has-inactive (= include-inactive? (true? (some #(= (parse-uuid (:menu/id %)) inactive-menu-id) body)))
+                          :detailed (every? #(= detailed? (not= (count (:menu/items %)) 0))
+                                            body)}]
+          (every? true? (vals conditions)))
         true true
         true false
         false true

--- a/test/pigeon_scoops_backend/menu/integration_test.clj
+++ b/test/pigeon_scoops_backend/menu/integration_test.clj
@@ -35,17 +35,17 @@
           [active-menu-id inactive-menu-id])
     (testing "List menus"
       (are [include-inactive? detailed?]
-        (let [{:keys [status body]} (ts/test-endpoint :get "/v1/menus" {:use-auth? true
-                                                                        :params {:include-inactive include-inactive?
-                                                                                 :detailed detailed?}})
-              body (filter #(#{active-menu-id inactive-menu-id} (parse-uuid (:menu/id %))) body)
-              conditions {:status (= status 200)
-                          :not-empty (pos? (count body))
-                          :has-active (some #(= (parse-uuid (:menu/id %)) active-menu-id) body)
-                          :has-inactive (= include-inactive? (true? (some #(= (parse-uuid (:menu/id %)) inactive-menu-id) body)))
-                          :detailed (every? #(= detailed? (not= (count (:menu/items %)) 0))
-                                            body)}]
-          (every? true? (vals conditions)))
+           (let [{:keys [status body]} (ts/test-endpoint :get "/v1/menus" {:use-auth? true
+                                                                           :params {:include-inactive include-inactive?
+                                                                                    :detailed detailed?}})
+                 body (filter #(#{active-menu-id inactive-menu-id} (parse-uuid (:menu/id %))) body)
+                 conditions {:status (= status 200)
+                             :not-empty (pos? (count body))
+                             :has-active (some #(= (parse-uuid (:menu/id %)) active-menu-id) body)
+                             :has-inactive (= include-inactive? (true? (some #(= (parse-uuid (:menu/id %)) inactive-menu-id) body)))
+                             :detailed (every? #(= detailed? (not= (count (:menu/items %)) 0))
+                                               body)}]
+             (every? true? (vals conditions)))
         true true
         true false
         false true

--- a/test/pigeon_scoops_backend/menu/integration_test.clj
+++ b/test/pigeon_scoops_backend/menu/integration_test.clj
@@ -1,5 +1,5 @@
 (ns pigeon-scoops-backend.menu.integration-test
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [are deftest is testing use-fixtures]]
             [pigeon-scoops-backend.test-system :as ts]))
 
 (use-fixtures :once ts/system-fixture (ts/make-account-fixture) (ts/make-roles-fixture :manage-recipes :manage-menus))
@@ -19,10 +19,35 @@
    :recipe/instructions ["make them"]})
 
 (deftest menus-list-test
-  (testing "List menus"
-    (let [{:keys [status body]} (ts/test-endpoint :get "/v1/menus" {:use-auth? true})]
-      (is (= 200 status))
-      (is (vector? body)))))
+  (let [active-menu-id (-> (ts/test-endpoint :post "/v1/menus" {:use-auth? true :body (assoc menu :menu/active true)})
+                           :body
+                           :id
+                           (parse-uuid))
+        inactive-menu-id (-> (ts/test-endpoint :post "/v1/menus" {:use-auth? true :body (assoc menu :menu/active false)})
+                             :body
+                             :id
+                             (parse-uuid))
+        recipe-id (-> (ts/test-endpoint :post "/v1/recipes" {:use-auth? true :body recipe})
+                      :body
+                      :id)]
+    (mapv #(ts/test-endpoint :post (str "/v1/menus/" % "/items")
+                             {:use-auth? true :body {:menu-item/recipe-id recipe-id}})
+          [active-menu-id inactive-menu-id])
+    (testing "List menus"
+      (are [include-inactive? detailed?]
+        (let [{:keys [status body]} (ts/test-endpoint :get "/v1/menus" {:use-auth? true
+                                                                        :params {:include-inactive include-inactive?
+                                                                                 :detailed detailed?}})]
+          (and (= status 200)
+               (vector? body)
+               (some #(= (parse-uuid (:menu/id %)) active-menu-id) body)
+               (= include-inactive? (true? (some #(= (parse-uuid (:menu/id %)) inactive-menu-id) body)))
+               (every? #(= detailed? (not= (count (:menu/items %)) 0))
+                       body)))
+        true true
+        true false
+        false true
+        false false))))
 
 (deftest menus-crud-test
   (let [menu-id (atom nil)

--- a/test/pigeon_scoops_backend/user_order/integration_test.clj
+++ b/test/pigeon_scoops_backend/user_order/integration_test.clj
@@ -3,7 +3,8 @@
             [integrant.repl.state :as state]
             [pigeon-scoops-backend.test-system :as ts]
             [pigeon-scoops-backend.user-order.db :as order-db]
-            [pigeon-scoops-backend.user-order.responses :refer [status terminal?]]))
+            [pigeon-scoops-backend.user-order.responses :refer [status terminal?]]
+            [clojure.pprint :refer [pprint]]))
 
 (use-fixtures :once ts/system-fixture (ts/make-account-fixture) (ts/make-roles-fixture [:manage-recipes :manage-orders :manage-menus :manage-production] [:manage-recipes :manage-orders :manage-menus]))
 
@@ -36,44 +37,57 @@
 
 (deftest orders-list-test
   (let [recipe-id (get-in (ts/test-endpoint :post "/v1/recipes" {:use-auth? true :body recipe}) [:body :id])
-        menu-id (get-in (ts/test-endpoint :post "/v1/menus" {:use-auth? true :body menu}) [:body :id])
-        _ (ts/test-endpoint :post (str "/v1/menus/" menu-id "/items")
-                            {:use-auth? true :body {:menu-item/recipe-id recipe-id}})
+        menu-id (-> (ts/test-endpoint :post "/v1/menus" {:use-auth? true :body menu})
+                    :body
+                    :id)
+        menu-item-id (-> (ts/test-endpoint :post (str "/v1/menus/" menu-id "/items")
+                                           {:use-auth? true :body {:menu-item/recipe-id recipe-id}})
+                         :body
+                         :id)
         admin-order-id (-> (ts/test-endpoint :post "/v1/orders" {:use-auth? true :body order})
                            :body
-                           :id)
+                           :id
+                           (parse-uuid))
         other-order-id (-> (ts/test-endpoint :post "/v1/orders" {:use-auth? true :body order :use-other-user true})
                            :body
-                           :id)]
+                           :id
+                           (parse-uuid))]
+    (ts/test-endpoint :post (str "/v1/menus/" menu-id "/items/" menu-item-id "/sizes")
+                      {:use-auth? true :body {:menu-item-size/amount 1
+                                              :menu-item-size/amount-unit :volume/qt}})
     (mapv (fn [[order-id use-other-user?]]
-            (ts/test-endpoint :post (str "/v1/orders/" order-id)
+            (ts/test-endpoint :post (str "/v1/orders/" order-id "/items")
                               {:use-auth? true
                                :use-other-user use-other-user?
                                :body (assoc order-item :order-item/recipe-id recipe-id)}))
           [[admin-order-id false] [other-order-id true]])
     (testing "List orders"
-      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true})]
+      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true})
+            body (map #(update % :user-order/id parse-uuid) body)]
         (is (= 200 status))
         (is (pos? (count body)))
         (is ((set (map :user-order/id body)) admin-order-id))
         (is (not ((set (map :user-order/id body)) other-order-id)))
         (is (every? nil? (map :user-order/items body)))))
-    (testing "List orders with detauls"
-      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders?detailed=true" {:use-auth? true})
+    (testing "List orders with details"
+      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders?detailed=true&admin=true" {:use-auth? true})
             body (filter #(#{admin-order-id other-order-id} (parse-uuid (:user-order/id %))) body)]
+        (pprint body)
         (is (= 200 status))
         (is (pos? (count body)))
-        (is ((set (map :user-order/id body)) admin-order-id))
-        (is (not ((set (map :user-order/id body)) other-order-id)))
+        (is ((set (map (comp parse-uuid :user-order/id) body)) admin-order-id))
+        (is ((set (map (comp parse-uuid :user-order/id) body)) other-order-id))
         (is (every? seq (map :user-order/items body)))))
     (testing "List orders. admins can get orders from all users"
-      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true :params {:admin true}})]
+      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true :params {:admin true}})
+            body (map #(update % :user-order/id parse-uuid) body)]
         (is (= 200 status))
         (is (pos? (count body)))
         (is ((set (map :user-order/id body)) admin-order-id))
         (is ((set (map :user-order/id body)) other-order-id))))
     (testing "List orders. non admins cannot get orders from all users"
-      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true :use-other-user true :params {:admin true}})]
+      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true :use-other-user true :params {:admin true}})
+            body (map #(update % :user-order/id parse-uuid) body)]
         (is (= 200 status))
         (is (pos? (count body)))
         (is (not ((set (map :user-order/id body)) admin-order-id)))

--- a/test/pigeon_scoops_backend/user_order/integration_test.clj
+++ b/test/pigeon_scoops_backend/user_order/integration_test.clj
@@ -35,28 +35,47 @@
    :menu/duration-type :duration/month})
 
 (deftest orders-list-test
-  (let [admin-order-id (-> (ts/test-endpoint :post "/v1/orders" {:use-auth? true :body order})
+  (let [recipe-id (get-in (ts/test-endpoint :post "/v1/recipes" {:use-auth? true :body recipe}) [:body :id])
+        menu-id (get-in (ts/test-endpoint :post "/v1/menus" {:use-auth? true :body menu}) [:body :id])
+        _ (ts/test-endpoint :post (str "/v1/menus/" menu-id "/items")
+                            {:use-auth? true :body {:menu-item/recipe-id recipe-id}})
+        admin-order-id (-> (ts/test-endpoint :post "/v1/orders" {:use-auth? true :body order})
                            :body
                            :id)
         other-order-id (-> (ts/test-endpoint :post "/v1/orders" {:use-auth? true :body order :use-other-user true})
                            :body
                            :id)]
+    (mapv (fn [[order-id use-other-user?]]
+            (ts/test-endpoint :post (str "/v1/orders/" order-id)
+                              {:use-auth? true
+                               :use-other-user use-other-user?
+                               :body (assoc order-item :order-item/recipe-id recipe-id)}))
+          [[admin-order-id false] [other-order-id true]])
     (testing "List orders"
       (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true})]
         (is (= 200 status))
-        (is (vector? body))
+        (is (pos? (count body)))
         (is ((set (map :user-order/id body)) admin-order-id))
-        (is (not ((set (map :user-order/id body)) other-order-id)))))
+        (is (not ((set (map :user-order/id body)) other-order-id)))
+        (is (every? nil? (map :user-order/items body)))))
+    (testing "List orders with detauls"
+      (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders?detailed=true" {:use-auth? true})
+            body (filter #(#{admin-order-id other-order-id} (parse-uuid (:user-order/id %))) body)]
+        (is (= 200 status))
+        (is (pos? (count body)))
+        (is ((set (map :user-order/id body)) admin-order-id))
+        (is (not ((set (map :user-order/id body)) other-order-id)))
+        (is (every? seq (map :user-order/items body)))))
     (testing "List orders. admins can get orders from all users"
       (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true :params {:admin true}})]
         (is (= 200 status))
-        (is (vector? body))
+        (is (pos? (count body)))
         (is ((set (map :user-order/id body)) admin-order-id))
         (is ((set (map :user-order/id body)) other-order-id))))
     (testing "List orders. non admins cannot get orders from all users"
       (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders" {:use-auth? true :use-other-user true :params {:admin true}})]
         (is (= 200 status))
-        (is (vector? body))
+        (is (pos? (count body)))
         (is (not ((set (map :user-order/id body)) admin-order-id)))
         (is ((set (map :user-order/id body)) other-order-id))))))
 

--- a/test/pigeon_scoops_backend/user_order/integration_test.clj
+++ b/test/pigeon_scoops_backend/user_order/integration_test.clj
@@ -3,8 +3,7 @@
             [integrant.repl.state :as state]
             [pigeon-scoops-backend.test-system :as ts]
             [pigeon-scoops-backend.user-order.db :as order-db]
-            [pigeon-scoops-backend.user-order.responses :refer [status terminal?]]
-            [clojure.pprint :refer [pprint]]))
+            [pigeon-scoops-backend.user-order.responses :refer [status terminal?]]))
 
 (use-fixtures :once ts/system-fixture (ts/make-account-fixture) (ts/make-roles-fixture [:manage-recipes :manage-orders :manage-menus :manage-production] [:manage-recipes :manage-orders :manage-menus]))
 
@@ -72,7 +71,6 @@
     (testing "List orders with details"
       (let [{:keys [status body]} (ts/test-endpoint :get "/v1/orders?detailed=true&admin=true" {:use-auth? true})
             body (filter #(#{admin-order-id other-order-id} (parse-uuid (:user-order/id %))) body)]
-        (pprint body)
         (is (= 200 status))
         (is (pos? (count body)))
         (is ((set (map (comp parse-uuid :user-order/id) body)) admin-order-id))


### PR DESCRIPTION
In the front end, I'd like to occasionally get orders and menu lists with sub entities (menu items/sizes, order items)