### PR TITLE
add menu item size reference to order item and fix order status inference

### DIFF
--- a/resources/db/migrations/V9__menu_item_size_reference.sql
+++ b/resources/db/migrations/V9__menu_item_size_reference.sql
@@ -1,0 +1,3 @@
+ALTER TABLE order_item
+    ADD COLUMN IF NOT EXISTS menu_item_size_id UUID
+    REFERENCES menu_item_size(id) ON DELETE SET NULL;

--- a/src/pigeon_scoops_backend/user_order/db.clj
+++ b/src/pigeon_scoops_backend/user_order/db.clj
@@ -36,13 +36,13 @@
                        (if user-id
                          {:user-order/user-id user-id}
                          :all))
-               order-items (when detailed?
-                             (->> orders
-                                  (map :user-order/id)
-                                  (apply (partial find-all-order-items db))))]
+               order-items (->> orders
+                                (map :user-order/id)
+                                (apply (partial find-all-order-items db)))]
            (->> orders
                 (mapv #(assoc % :user-order/status (infer-order-status (get order-items (:user-order/id %)))
-                              :user-order/items (get order-items (:user-order/id %))))
+                              :user-order/items (when detailed?
+                                                  (get order-items (:user-order/id %)))))
                 (mapv #(apply-db-str->keyword % :user-order/amount-unit :user-order/status)))))))
 
 (defn find-order-by-id [db order-id]

--- a/src/pigeon_scoops_backend/user_order/responses.clj
+++ b/src/pigeon_scoops_backend/user_order/responses.clj
@@ -24,7 +24,8 @@
    (ds/opt :order-item/amount-unit) (s/and keyword?
                                            (set (concat common/other-units
                                                         (keys mass/conversion-map)
-                                                        (keys volume/conversion-map))))})
+                                                        (keys volume/conversion-map))))
+   (ds/opt :order-item/menu-item-size-id) uuid?})
 
 (def order
   {:user-order/id             uuid?

--- a/src/pigeon_scoops_backend/user_order/routes.clj
+++ b/src/pigeon_scoops_backend/user_order/routes.clj
@@ -50,7 +50,8 @@
                                         :order-item/amount      number?
                                         :order-item/amount-unit (s/and keyword? (set (concat common/other-units
                                                                                              (keys mass/conversion-map)
-                                                                                             (keys volume/conversion-map))))}}
+                                                                                             (keys volume/conversion-map))))
+                                        (ds/opt :order-item/menu-item-size-id) (s/nilable uuid?)}}
                     :responses  {201 {:body {:id uuid?}}}
                     :summary    "Create order-item"}}]
       ["/:order-item-id"
@@ -60,7 +61,8 @@
                                            :order-item/amount      number?
                                            :order-item/amount-unit (s/and keyword? (set (concat common/other-units
                                                                                                 (keys mass/conversion-map)
-                                                                                                (keys volume/conversion-map))))}}
+                                                                                                (keys volume/conversion-map))))
+                                           (ds/opt :order-item/menu-item-size-id) (s/nilable uuid?)}}
                        :responses  {204 {:body nil?}}
                        :summary    "Update order-item"}
             :delete {:handler    (order/delete-order-item! db)


### PR DESCRIPTION
we still need to retrieve order items for non-detailed list response so we can infer order status.

it'll also be nice if we can reference what menu item size an order item rferences